### PR TITLE
Initialise MonotonicFunction with lastUlid far in the past

### DIFF
--- a/src/main/java/com/github/f4b6a3/ulid/UlidFactory.java
+++ b/src/main/java/com/github/f4b6a3/ulid/UlidFactory.java
@@ -26,6 +26,7 @@ package com.github.f4b6a3.ulid;
 
 import java.security.SecureRandom;
 import java.time.Clock;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.Random;
 import java.util.function.IntFunction;
@@ -360,7 +361,7 @@ public final class UlidFactory {
 		}
 
 		void initialize(LongSupplier timeFunction) {
-			this.lastUlid = new Ulid(timeFunction.getAsLong(), this.random.nextBytes(Ulid.RANDOM_BYTES));
+			this.lastUlid = new Ulid(Instant.MIN.toEpochMilli(), this.random.nextBytes(Ulid.RANDOM_BYTES));
 		}
 
 		@Override


### PR DESCRIPTION
Without this, things can trip up unnecessarily when the call to generate the first ULID is very close to the initialisation of the factory.