### PR TITLE
Upgrade JDK version to 11, Add module-info.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	</developers>
 
 	<properties>
-		<jdk.version>8</jdk.version>
+		<jdk.version>11</jdk.version>
 		<package.name>com.github.f4b6a3.ulid</package.name>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
@@ -68,8 +68,6 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
-							<!-- Java Modularity -->
-							<Automatic-Module-Name>${package.name}</Automatic-Module-Name>
 							<!-- OSGi Modularity -->
 							<Bundle-ManifestVersion>2</Bundle-ManifestVersion>
 							<Bundle-Name>${project.artifactId}</Bundle-Name>

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module com.github.f4b6a3.ulid {
+    exports com.github.f4b6a3.ulid;
+}


### PR DESCRIPTION
As the title says. Updates  to JDK 11 (the oldest LTS version to support the Java Platform Module System), and adds a `module-info.java` so that this project may be used in modern, modular java projects without having to wrangle auto-modules.