### PR TITLE
prepare for new release mechanism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [5.2.4] - 2025-12-24
+
+- use new release mechanism, see this [blog post](https://central.sonatype.org/news/20250326_ossrh_sunset/#support-for-gradle-and-other-publishers).
+
 ## [5.2.3] - 2024-01-02
 
 - Fix `ArrayIndexOutOfBoundsException` on input with multiple bytes for a character. #32

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ In summary:
 * String format is encoded to [Crockford's base32](https://www.crockford.com/base32.html);
 * String format is URL safe, is case insensitive, and has no hyphens.
 
-This project contains a [micro benchmark](https://github.com/f4b6a3/ulid-creator/tree/master/benchmark) and a good amount of [unit tests](https://github.com/f4b6a3/ulid-creator/tree/master/src/test/java/com/github/f4b6a3/ulid).
+This project contains a [micro benchmark](https://github.com/f4b6a3/ulid-creator/tree/master/benchmark) and a good amount of [unit tests](https://github.com/f4b6a3/ulid-creator/tree/master/src/test/java/io/github/f4b6a3/ulid).
 
-The jar file can be downloaded directly from [maven.org](https://repo1.maven.org/maven2/com/github/f4b6a3/ulid-creator/).
+The jar file can be downloaded directly from [maven.org](https://repo1.maven.org/maven2/io/github/f4b6a3/ulid-creator/).
 
-Read the [Javadocs](https://javadoc.io/doc/com.github.f4b6a3/ulid-creator).
+Read the [Javadocs](https://javadoc.io/doc/io.github.f4b6a3/ulid-creator).
 
 Usage
 ------------------------------------------------------
@@ -39,21 +39,21 @@ Ulid ulid = UlidCreator.getMonotonicUlid();
 Add these lines to your `pom.xml`.
 
 ```xml
-<!-- https://search.maven.org/artifact/com.github.f4b6a3/ulid-creator -->
+<!-- https://search.maven.org/artifact/io.github.f4b6a3/ulid-creator -->
 <dependency>
-  <groupId>com.github.f4b6a3</groupId>
+  <groupId>io.github.f4b6a3</groupId>
   <artifactId>ulid-creator</artifactId>
   <version>5.2.3</version>
 </dependency>
 ```
-See more options in [maven.org](https://search.maven.org/artifact/com.github.f4b6a3/ulid-creator).
+See more options in [maven.org](https://search.maven.org/artifact/io.github.f4b6a3/ulid-creator).
 
 ### Modularity
 
 Module and bundle names are the same as the root package name.
 
-- JPMS module name: `com.github.f4b6a3.ulid`
-- OSGi symbolic name: `com.github.f4b6a3.ulid`
+- JPMS module name: `io.github.f4b6a3.ulid`
+- OSGi symbolic name: `io.github.f4b6a3.ulid`
 
 ### ULID
 
@@ -243,7 +243,7 @@ A key generator that makes substitution easy if necessary:
 ```java
 package com.example;
 
-import com.github.f4b6a3.ulid.UlidCreator;
+import io.github.f4b6a3.ulid.UlidCreator;
 
 public class KeyGenerator {
     public static String next() {

--- a/benchmark/src/main/java/benchmark/Throughput.java
+++ b/benchmark/src/main/java/benchmark/Throughput.java
@@ -1,22 +1,12 @@
 
 package benchmark;
 
+import io.github.f4b6a3.ulid.Ulid;
+import io.github.f4b6a3.ulid.UlidCreator;
+import org.openjdk.jmh.annotations.*;
+
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
-import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.BenchmarkMode;
-import org.openjdk.jmh.annotations.Fork;
-import org.openjdk.jmh.annotations.Measurement;
-import org.openjdk.jmh.annotations.Mode;
-import org.openjdk.jmh.annotations.OutputTimeUnit;
-import org.openjdk.jmh.annotations.Scope;
-import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.Threads;
-import org.openjdk.jmh.annotations.Warmup;
-
-import com.github.f4b6a3.ulid.Ulid;
-import com.github.f4b6a3.ulid.UlidCreator;
 
 @Fork(1)
 @Threads(4)

--- a/docs/run.sh
+++ b/docs/run.sh
@@ -10,5 +10,5 @@ cd "${SCRIPT_DIR}/.."
 rm -rf docs/javadoc
 
 # generate new docs
-find src/main/java/com/github/f4b6a3/ulid/ -name "*.java" | xargs javadoc -d docs/javadoc
+find src/main/java/io/github/f4b6a3/ulid/ -name "*.java" | xargs javadoc -d docs/javadoc
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.github.f4b6a3</groupId>
+	<groupId>io.github.f4b6a3</groupId>
 	<artifactId>ulid-creator</artifactId>
 	<version>5.2.4-SNAPSHOT</version>
 	<packaging>jar</packaging>
@@ -26,7 +26,7 @@
 
 	<properties>
 		<jdk.version>8</jdk.version>
-		<package.name>com.github.f4b6a3.ulid</package.name>
+		<package.name>io.github.f4b6a3.ulid</package.name>
 		<maven.compiler.source>${jdk.version}</maven.compiler.source>
 		<maven.compiler.target>${jdk.version}</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -48,23 +48,12 @@
 		<tag>HEAD</tag>
 	</scm>
 
-	<distributionManagement>
-		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-		</snapshotRepository>
-		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-		</repository>
-	</distributionManagement>
-
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
-				<version>3.2.0</version>
+				<version>3.5.0</version>
 				<configuration>
 					<archive>
 						<manifestEntries>
@@ -81,16 +70,28 @@
 					</archive>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>3.2.0</version>
-				<configuration>
-				</configuration>
-			</plugin>
-			<plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.12.0</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <failOnError>false</failOnError>  <!-- Skip strict errors for now; set to true later -->
+                    <additionalOptions>
+                        <additionalOption>-Xdoclint:none</additionalOption>  <!-- Suppress warnings on JDK 8+ -->
+                    </additionalOptions>
+                </configuration>
+            </plugin>
+            <plugin>
 				<artifactId>maven-deploy-plugin</artifactId>
-				<version>2.8.2</version>
+				<version>3.1.4</version>
 				<executions>
 					<execution>
 						<id>default-deploy</id>
@@ -104,7 +105,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.3</version>
+				<version>3.3.1</version>
 				<configuration>
 					<localCheckout>true</localCheckout>
 					<pushChanges>false</pushChanges>
@@ -115,25 +116,27 @@
 					<dependency>
 						<groupId>org.apache.maven.scm</groupId>
 						<artifactId>maven-scm-provider-gitexe</artifactId>
-						<version>1.9.5</version>
+						<version>2.2.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.13</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<autoReleaseAfterClose>true</autoReleaseAfterClose>
-				</configuration>
-			</plugin>
-			<plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.9.0</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <!-- Optional: Auto-publish if validation passes (recommended for CI/open-source) -->
+                    <autoPublish>true</autoPublish>
+                    <!-- Optional: Wait until published and fail if not -->
+                    <waitUntil>published</waitUntil>
+                </configuration>
+            </plugin>
+            <plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>3.0.1</version>
+				<version>3.4.0</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -161,7 +164,7 @@
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-gpg-plugin</artifactId>
-						<version>1.6</version>
+						<version>3.2.8</version>
 						<executions>
 							<execution>
 								<id>sign-artifacts</id>

--- a/src/main/java/io/github/f4b6a3/ulid/Ulid.java
+++ b/src/main/java/io/github/f4b6a3/ulid/Ulid.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import java.io.Serializable;
 import java.time.Instant;

--- a/src/main/java/io/github/f4b6a3/ulid/UlidCreator.java
+++ b/src/main/java/io/github/f4b6a3/ulid/UlidCreator.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;

--- a/src/main/java/io/github/f4b6a3/ulid/UlidFactory.java
+++ b/src/main/java/io/github/f4b6a3/ulid/UlidFactory.java
@@ -22,7 +22,7 @@
  * SOFTWARE.
  */
 
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import java.security.SecureRandom;
 import java.util.Objects;

--- a/src/test/java/io/github/f4b6a3/ulid/TestSuite.java
+++ b/src/test/java/io/github/f4b6a3/ulid/TestSuite.java
@@ -1,4 +1,4 @@
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;

--- a/src/test/java/io/github/f4b6a3/ulid/UlidFactoryDefaultfTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/UlidFactoryDefaultfTest.java
@@ -1,4 +1,4 @@
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import org.junit.Test;
 

--- a/src/test/java/io/github/f4b6a3/ulid/UlidFactoryMonotonicTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/UlidFactoryMonotonicTest.java
@@ -1,4 +1,4 @@
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import org.junit.Test;
 

--- a/src/test/java/io/github/f4b6a3/ulid/UlidFactoryTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/UlidFactoryTest.java
@@ -1,4 +1,4 @@
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;

--- a/src/test/java/io/github/f4b6a3/ulid/UlidTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/UlidTest.java
@@ -1,4 +1,4 @@
-package com.github.f4b6a3.ulid;
+package io.github.f4b6a3.ulid;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/src/test/java/io/github/f4b6a3/ulid/demo/DemoTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/demo/DemoTest.java
@@ -1,6 +1,6 @@
-package com.github.f4b6a3.ulid.demo;
+package io.github.f4b6a3.ulid.demo;
 
-import com.github.f4b6a3.ulid.UlidCreator;
+import io.github.f4b6a3.ulid.UlidCreator;
 
 public class DemoTest {
 

--- a/src/test/java/io/github/f4b6a3/ulid/uniq/UniquenessTest.java
+++ b/src/test/java/io/github/f4b6a3/ulid/uniq/UniquenessTest.java
@@ -1,11 +1,11 @@
-package com.github.f4b6a3.ulid.uniq;
+package io.github.f4b6a3.ulid.uniq;
 
 import java.util.HashSet;
 import java.util.Random;
 
-import com.github.f4b6a3.ulid.TestSuite;
-import com.github.f4b6a3.ulid.Ulid;
-import com.github.f4b6a3.ulid.UlidFactory;
+import io.github.f4b6a3.ulid.TestSuite;
+import io.github.f4b6a3.ulid.Ulid;
+import io.github.f4b6a3.ulid.UlidFactory;
 
 /**
  * 


### PR DESCRIPTION
Sonatype changed their release mechanism. This patch prepares this project, so that it can be deployed onto central.
(see [this blog post](https://central.sonatype.org/news/20250326_ossrh_sunset/#support-for-gradle-and-other-publishers))